### PR TITLE
Mitigating code execution by sanitizing provided application identifier.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -49,6 +49,11 @@ export function makeAppFilter(appIdentifier: string): FilterCreator {
       throw new Error('App filter is only available for Android');
     }
 
+    if (!appIdentifier.match(/^[a-z]\w*(\.[a-z]\w*)+$/i))
+    {
+      throw new Error('Invalid App Identifier.')
+    }
+    
     const filter = new AndroidFilter(minPriority);
     filter.setFilterByApp(appIdentifier, adbPath);
     return filter;


### PR DESCRIPTION
Since the application identifier was being used in a command execution without any sanitization, adding a proper check for valid package naming convention in both iOS and Android, this bug is mitigated.

Fix in action:
<img width="519" alt="image" src="https://user-images.githubusercontent.com/2073268/77793043-cba41480-703f-11ea-8130-f7a0eb15c69b.png">
